### PR TITLE
CI: Add OS to job name

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 jobs:
-  build:
+  build-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 jobs:
-  build:
+  build-windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c


### PR DESCRIPTION
This will allow us to prevent merging unless all builds pass. Currently they all have the same job name so not able to add them all to the status check.