### PR TITLE
Fix windows opening and disappearing on start

### DIFF
--- a/src/progresswindow.cpp
+++ b/src/progresswindow.cpp
@@ -22,30 +22,8 @@ limitations under the License.
 ProgressWindow::ProgressWindow(QWidget *parent, QIcon icon)
 {
     m_icon = icon;
-
-    m_dialog = new QDialog(parent);
-    m_dialog->setWindowIcon(m_icon);
-    m_dialog->resize(300, 150);
-    m_dialog->setWindowFlags(Qt::FramelessWindowHint);
-    m_dialog->setModal(true);
-
-    QVBoxLayout form(m_dialog);
-
+    m_parent = parent;
     m_text = new QLabel();
-    m_text->setWordWrap(true);
-    form.addWidget(m_text);
-
-    m_progressBar = new QProgressBar();
-    form.addWidget(m_progressBar);
-
-    m_cancelButton = new QPushButton();
-    m_cancelButton->setText(tr("Cancel"));
-    connect(m_cancelButton, &QAbstractButton::clicked, this, &ProgressWindow::cancel);
-    form.addWidget(m_cancelButton);
-
-    // if the dialog isn't opened now it breaks formatting
-    m_dialog->open();
-    m_dialog->hide();
 }
 
 void ProgressWindow::setBarMaximum(int max)
@@ -65,6 +43,25 @@ void ProgressWindow::setText(QString text)
 
 void ProgressWindow::show()
 {
+    m_dialog = new QDialog(m_parent);
+    m_dialog->setWindowIcon(m_icon);
+    m_dialog->resize(300, 150);
+    m_dialog->setWindowFlags(Qt::FramelessWindowHint);
+    m_dialog->setModal(true);
+
+    QVBoxLayout form(m_dialog);
+
+    m_text->setWordWrap(true);
+    form.addWidget(m_text);
+
+    m_progressBar = new QProgressBar();
+    form.addWidget(m_progressBar);
+
+    m_cancelButton = new QPushButton();
+    m_cancelButton->setText(tr("Cancel"));
+    connect(m_cancelButton, &QAbstractButton::clicked, this, &ProgressWindow::cancel);
+    form.addWidget(m_cancelButton);
+
     m_dialog->open();
 }
 

--- a/src/progresswindow.h
+++ b/src/progresswindow.h
@@ -46,6 +46,7 @@ private:
     QProgressBar *m_progressBar;
     QPushButton *m_cancelButton;
     QIcon m_icon;
+    QWidget *m_parent;
 };
 
 #endif // PROGRESSWINDOW_H


### PR DESCRIPTION
On start two windows quickly open and then disappear, this prevents this from happening.
<img width="739" alt="Screenshot 2023-03-07 at 2 10 28 PM" src="https://user-images.githubusercontent.com/44844360/223565160-7af877d3-7196-4786-89f9-5e7c0cf8008b.png">
