### PR TITLE
Use minikube binary set in settings for commands

### DIFF
--- a/src/basicview.cpp
+++ b/src/basicview.cpp
@@ -112,7 +112,6 @@ BasicView::BasicView(QIcon icon)
 
     connect(topStatusButton, &QPushButton::clicked, this, &BasicView::refresh);
     connect(startButton, &QPushButton::clicked, this, &BasicView::start);
-    connect(startButton, &QPushButton::clicked, this, &BasicView::start);
     connect(stopButton, &QAbstractButton::clicked, this, &BasicView::stop);
     connect(pauseButton, &QAbstractButton::clicked, this, &BasicView::pause);
     connect(deleteButton, &QAbstractButton::clicked, this, &BasicView::delete_);
@@ -311,4 +310,29 @@ void BasicView::askSettings()
 void BasicView::receivedSettings(Setting s)
 {
     m_setting = s;
+}
+
+void BasicView::minikubeNotFound()
+{
+    QDialog dialog;
+    dialog.setWindowTitle("minikube");
+    dialog.setWindowIcon(m_icon);
+    dialog.setModal(true);
+    QFormLayout form(&dialog);
+    QLabel *message = new QLabel();
+    message->setText("minikube was not found on the path.\nPlease follow the install instructions "
+                     "below to install minikube first.\nIf you do have minikube installed set the "
+                     "location in the settings.\n");
+    form.addWidget(message);
+    QLabel *link = new QLabel();
+    link->setOpenExternalLinks(true);
+    link->setText("<a "
+                  "href='https://minikube.sigs.k8s.io/docs/start/'>https://minikube.sigs.k8s.io/"
+                  "docs/start/</a>");
+    form.addWidget(link);
+    QDialogButtonBox buttonBox(Qt::Horizontal, &dialog);
+    buttonBox.addButton(QString(tr("OK")), QDialogButtonBox::AcceptRole);
+    connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    form.addRow(&buttonBox);
+    dialog.exec();
 }

--- a/src/basicview.h
+++ b/src/basicview.h
@@ -37,6 +37,7 @@ public:
     void disableButtons();
     void setFont(QFont font, QWidget *wid);
     void receivedSettings(Setting s);
+    void minikubeNotFound();
 signals:
     void start();
     void stop();

--- a/src/commandrunner.h
+++ b/src/commandrunner.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "cluster.h"
 #include "addon.h"
 #include "logger.h"
+#include "settings.h"
 
 #include <QDialog>
 #include <QProcessEnvironment>
@@ -29,7 +30,7 @@ class CommandRunner : public QObject
     Q_OBJECT
 
 public:
-    CommandRunner(QDialog *parent, Logger *logger);
+    CommandRunner(QDialog *parent, Logger *logger, Settings *settings);
 
     void executeCommand(QString program, QStringList args);
     void startMinikube(QStringList args);
@@ -57,6 +58,7 @@ signals:
     void updatedAddons(AddonList);
     void startCommandStarting();
     void addonsComplete();
+    void minikubeNotFound();
 
 private slots:
     void executionCompleted();
@@ -66,7 +68,8 @@ private slots:
 private:
     void executeMinikubeCommand(QStringList args);
     void executeMinikubeCommand(QStringList args, QProcess *process);
-    void minikubePath();
+    QString minikubePath();
+    void errorHappened(QProcess::ProcessError);
 #if __APPLE__
     void setMinikubePath();
 #endif
@@ -74,10 +77,10 @@ private:
     QProcess *m_process;
     QProcessEnvironment m_env;
     QString m_output;
-    QString m_minikubePath;
     QString m_command;
     QDialog *m_parent;
     Logger *m_logger;
+    Settings *m_settings;
     QStringList m_args;
     bool m_isRunning;
 };

--- a/src/operator.h
+++ b/src/operator.h
@@ -65,6 +65,7 @@ private slots:
     void addonsReceived(AddonList as);
     void startCommandStarting();
     void addonsComplete();
+    void minikubeNotFound();
 
 private:
     QStringList getCurrentClusterFlags();

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -17,8 +17,20 @@ limitations under the License.
 #include "paths.h"
 
 #include <QDir>
+#include <QStandardPaths>
 
-QStringList Paths::minikubePaths()
+QStringList Paths::unixLocations()
 {
-    return { "/usr/local/bin", "/opt/homebrew/bin", QDir::homePath() + "/google-cloud-sdk/bin" };
+    return { "/usr/local/bin", "/opt/homebrew/bin" };
+}
+
+QString Paths::minikubePath()
+{
+    QString path = QStandardPaths::findExecutable("minikube");
+    if (!path.isEmpty()) {
+        return path;
+    }
+    return QStandardPaths::findExecutable(
+            "minikube",
+            { "/usr/local/bin", "/opt/homebrew/bin", QDir::homePath() + "/google-cloud-sdk/bin" });
 }

--- a/src/paths.h
+++ b/src/paths.h
@@ -22,7 +22,8 @@ limitations under the License.
 class Paths
 {
 public:
-    static QStringList minikubePaths();
+    static QStringList unixLocations();
+    static QString minikubePath();
 };
 
 #endif // PATHS_H

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -45,8 +45,7 @@ Setting Settings::getSettings()
 {
     QSettings *s = new QSettings(m_configPath, QSettings::IniFormat);
     Setting *setting = new Setting();
-    setting->setMinikubeBinaryPath(
-            s->value("minikube-binary-path", Paths::minikubePath()).toString());
+    setting->setMinikubeBinaryPath(s->value("minikube-binary-path").toString());
     setting->setSkipWarningOnClose(s->value("skip-warning-on-close").toBool());
     return *setting;
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 #include "settings.h"
+#include "paths.h"
 
 #include <QSettings>
 #include <QDir>
@@ -26,6 +27,11 @@ Settings::Settings()
         dir.mkpath(".");
     }
     m_configPath = dir.filePath("config.ini");
+    QSettings settings(m_configPath, QSettings::IniFormat);
+    if (settings.contains("minikube-binary-path")) {
+        return;
+    }
+    settings.setValue("minikube-binary-path", Paths::minikubePath());
 }
 
 void Settings::updateSettings(Setting s)
@@ -39,7 +45,13 @@ Setting Settings::getSettings()
 {
     QSettings *s = new QSettings(m_configPath, QSettings::IniFormat);
     Setting *setting = new Setting();
-    setting->setMinikubeBinaryPath(s->value("minikube-binary-path").toString());
+    setting->setMinikubeBinaryPath(
+            s->value("minikube-binary-path", Paths::minikubePath()).toString());
     setting->setSkipWarningOnClose(s->value("skip-warning-on-close").toBool());
     return *setting;
+}
+
+QString Settings::minikubePath()
+{
+    return getSettings().minikubeBinaryPath();
 }

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,6 +30,7 @@ public:
     Settings();
     Setting getSettings();
     void updateSettings(Setting setting);
+    QString minikubePath();
 signals:
 
 private:

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -38,12 +38,12 @@ const QVersionNumber version = QVersionNumber::fromString("0.0.2");
 Window::Window()
 {
     trayIconIcon = new QIcon(":/resources/images/minikube.png");
-    checkForMinikube();
     Fonts::initFonts();
 
     stackedWidget = new QStackedWidget;
     logger = new Logger();
-    commandRunner = new CommandRunner(this, logger);
+    settings = new Settings();
+    commandRunner = new CommandRunner(this, logger, settings);
     basicView = new BasicView(*trayIconIcon);
     serviceView = new ServiceView(this, *trayIconIcon);
     addonsView = new AddonsView(*trayIconIcon);
@@ -53,7 +53,6 @@ Window::Window()
     tray = new Tray(*trayIconIcon);
     hyperKit = new HyperKit(*trayIconIcon);
     updater = new Updater(this, version, *trayIconIcon);
-    settings = new Settings();
 
     op = new Operator(advancedView, basicView, serviceView, addonsView, commandRunner, errorMessage,
                       progressWindow, tray, hyperKit, updater, settings, stackedWidget, this);
@@ -91,45 +90,6 @@ void Window::closeEvent(QCloseEvent *event)
         hide();
         event->ignore();
     }
-}
-
-static QString minikubePath()
-{
-    QString minikubePath = QStandardPaths::findExecutable("minikube");
-    if (!minikubePath.isEmpty()) {
-        return minikubePath;
-    }
-    return QStandardPaths::findExecutable("minikube", Paths::minikubePaths());
-}
-
-void Window::checkForMinikube()
-{
-    QString program = minikubePath();
-    if (!program.isEmpty()) {
-        return;
-    }
-
-    QDialog dialog;
-    dialog.setWindowTitle("minikube");
-    dialog.setWindowIcon(*trayIconIcon);
-    dialog.setModal(true);
-    QFormLayout form(&dialog);
-    QLabel *message = new QLabel(this);
-    message->setText("minikube was not found on the path.\nPlease follow the install instructions "
-                     "below to install minikube first.\n");
-    form.addWidget(message);
-    QLabel *link = new QLabel(this);
-    link->setOpenExternalLinks(true);
-    link->setText("<a "
-                  "href='https://minikube.sigs.k8s.io/docs/start/'>https://minikube.sigs.k8s.io/"
-                  "docs/start/</a>");
-    form.addWidget(link);
-    QDialogButtonBox buttonBox(Qt::Horizontal, &dialog);
-    buttonBox.addButton(QString(tr("OK")), QDialogButtonBox::AcceptRole);
-    connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-    form.addRow(&buttonBox);
-    dialog.exec();
-    exit(EXIT_FAILURE);
 }
 
 #endif

--- a/src/window.h
+++ b/src/window.h
@@ -65,7 +65,6 @@ protected:
 private:
     QIcon *trayIconIcon;
 
-    void checkForMinikube();
     QStackedWidget *stackedWidget;
     void checkForUpdates();
     QString getRequest(QString url);


### PR DESCRIPTION
On startup, if config is empty, sets a location if one is found in the path. If it's not found it outputs a message to the user.

Also found that we were calling minikube start twice every time the button was getting clicked, resolved.