### PR TITLE
docs: tell contributors to use qt5 in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ Open in [Qt Creator](https://doc.qt.io/qtcreator/) via:
 ```shell
 qtcreator minikube.pro
 ```
+* Note: This project is currently configured to use Qt 5 and will not work with Qt 6. If using Qt Creator, please use the following link to learn how to add Qt 5 to Qt Creator: https://doc.qt.io/qtcreator/creator-project-qmake.html
 
 #### From Command Line
 


### PR DESCRIPTION
I was trying to get familiar with minikube-gui, however, I found that documents didn't tell developers to use QT5. Currently QTCreator downloads and uses qt6 bydefault(actually qt6.5.x), which is incompatible with minikube-gui, and will cause compilation errors. 

But using qt5 was not specified in readme.md nor CONTRIBUTING.md. It is quite confusing and may waste a lot of time of new contributors. (Actually I realized that I should deupgrade qt by looking at CI configurations in Github Actions)

So I suggest that maybe we should mention this in CONTRIBUTING.md to save new developers' time?

