### PR TITLE
feat: make buttons blue when clickable and gray when not clickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ compile_commands.json
 *creator.user*
 
 .DS_Store
+
+# Vscode configurations
+.vscode

--- a/minikube.pro
+++ b/minikube.pro
@@ -10,6 +10,7 @@ HEADERS       = src/window.h \
                 src/fonts.h \
                 src/hyperkit.h \
                 src/logger.h \
+                src/minikubebutton.h \
                 src/mount.h \
                 src/operator.h \
                 src/paths.h \
@@ -31,6 +32,7 @@ SOURCES       = src/main.cpp \
                 src/fonts.cpp \
                 src/hyperkit.cpp \
                 src/logger.cpp \
+                src/minikubebutton.cpp \
                 src/operator.cpp \
                 src/paths.cpp \
                 src/progresswindow.cpp \

--- a/src/advancedview.cpp
+++ b/src/advancedview.cpp
@@ -46,16 +46,16 @@ AdvancedView::AdvancedView(QIcon icon)
     clusterListView->horizontalHeader()->setSectionResizeMode(6, QHeaderView::ResizeToContents);
     setSelectedClusterName("default");
 
-    startButton = new QPushButton(tr("Start"));
-    stopButton = new QPushButton(tr("Stop"));
-    pauseButton = new QPushButton(tr("Pause"));
-    deleteButton = new QPushButton(tr("Delete"));
-    refreshButton = new QPushButton(tr("Refresh"));
-    createButton = new QPushButton(tr("Create"));
-    dockerEnvButton = new QPushButton("docker-env");
-    sshButton = new QPushButton("SSH");
-    dashboardButton = new QPushButton(tr("Dashboard"));
-    basicButton = new QPushButton(tr("Basic View"));
+    startButton = new MinikubeButton(tr("Start"));
+    stopButton = new MinikubeButton(tr("Stop"));
+    pauseButton = new MinikubeButton(tr("Pause"));
+    deleteButton = new MinikubeButton(tr("Delete"));
+    refreshButton = new MinikubeButton(tr("Refresh"));
+    createButton = new MinikubeButton(tr("Create"));
+    dockerEnvButton = new MinikubeButton("docker-env");
+    sshButton = new MinikubeButton("SSH");
+    dashboardButton = new MinikubeButton(tr("Dashboard"));
+    basicButton = new MinikubeButton(tr("Basic View"));
 
     disableButtons();
 

--- a/src/advancedview.h
+++ b/src/advancedview.h
@@ -18,6 +18,7 @@ limitations under the License.
 #define ADVANCEDVIEW_H
 
 #include "cluster.h"
+#include "minikubebutton.h"
 
 #include <QLabel>
 #include <QPushButton>
@@ -58,16 +59,16 @@ private:
     void askName();
     void askCustom();
 
-    QPushButton *startButton;
-    QPushButton *stopButton;
-    QPushButton *pauseButton;
-    QPushButton *deleteButton;
-    QPushButton *refreshButton;
-    QPushButton *dockerEnvButton;
-    QPushButton *sshButton;
-    QPushButton *dashboardButton;
-    QPushButton *basicButton;
-    QPushButton *createButton;
+    MinikubeButton *startButton;
+    MinikubeButton *stopButton;
+    MinikubeButton *pauseButton;
+    MinikubeButton *deleteButton;
+    MinikubeButton *refreshButton;
+    MinikubeButton *dockerEnvButton;
+    MinikubeButton *sshButton;
+    MinikubeButton *dashboardButton;
+    MinikubeButton *basicButton;
+    MinikubeButton *createButton;
     QLabel *loading;
     ClusterModel *m_clusterModel;
 

--- a/src/basicview.cpp
+++ b/src/basicview.cpp
@@ -38,24 +38,23 @@ BasicView::BasicView(QIcon icon)
     QVBoxLayout *topBar = new QVBoxLayout;
     topBar->addWidget(topStatusButton);
 
-    startButton = new QPushButton(Constants::startIcon);
-    stopButton = new QPushButton(Constants::stopIcon);
-    pauseButton = new QPushButton(Constants::pauseIcon);
-    deleteButton = new QPushButton(Constants::deleteIcon);
+    startButton = new MinikubeButton(Constants::startIcon);
+    stopButton = new MinikubeButton(Constants::stopIcon);
+    pauseButton = new MinikubeButton(Constants::pauseIcon);
+    deleteButton = new MinikubeButton(Constants::deleteIcon);
 
-    dockerEnvButton = new QPushButton("docker-env");
-    serviceButton = new QPushButton("service");
-    mountButton = new QPushButton(tr("mount"));
-    tunnelButton = new QPushButton(tr("tunnel"));
-    sshButton = new QPushButton("SSH");
-    dashboardButton = new QPushButton(tr("dashboard"));
-    addonsButton = new QPushButton(tr("addons"));
-    advancedButton = new QPushButton(tr("cluster list"));
-
-    refreshButton = new QPushButton(Constants::refreshIcon);
-    settingsButton = new QPushButton(Constants::settingsIcon);
-    aboutButton = new QPushButton(Constants::aboutIcon);
-    exitButton = new QPushButton(Constants::exitIcon);
+    dockerEnvButton = new MinikubeButton("docker-env");
+    serviceButton = new MinikubeButton("service");
+    mountButton = new MinikubeButton(tr("mount"));
+    tunnelButton = new MinikubeButton(tr("tunnel"));
+    sshButton = new MinikubeButton("SSH");
+    dashboardButton = new MinikubeButton(tr("dashboard"));
+    addonsButton = new MinikubeButton(tr("addons"));
+    advancedButton = new MinikubeButton(tr("cluster list"));
+    refreshButton = new MinikubeButton(Constants::refreshIcon);
+    settingsButton = new MinikubeButton(Constants::settingsIcon);
+    aboutButton = new MinikubeButton(Constants::aboutIcon);
+    exitButton = new MinikubeButton(Constants::exitIcon);
 
     // all the buttons that have icon needs to be set here
     Fonts::setFontAwesome(startButton);

--- a/src/basicview.h
+++ b/src/basicview.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "cluster.h"
 #include "mount.h"
 #include "setting.h"
+#include "minikubebutton.h"
 
 #include <QPushButton>
 #include <QLabel>
@@ -57,22 +58,22 @@ signals:
 
 private:
     QPushButton *topStatusButton;
-    QPushButton *startButton;
-    QPushButton *stopButton;
-    QPushButton *pauseButton;
-    QPushButton *deleteButton;
-    QPushButton *refreshButton;
-    QPushButton *dockerEnvButton;
-    QPushButton *serviceButton;
-    QPushButton *mountButton;
-    QPushButton *tunnelButton;
-    QPushButton *sshButton;
-    QPushButton *dashboardButton;
-    QPushButton *addonsButton;
-    QPushButton *advancedButton;
-    QPushButton *settingsButton;
-    QPushButton *aboutButton;
-    QPushButton *exitButton;
+    MinikubeButton *startButton;
+    MinikubeButton *stopButton;
+    MinikubeButton *pauseButton;
+    MinikubeButton *deleteButton;
+    MinikubeButton *refreshButton;
+    MinikubeButton *dockerEnvButton;
+    MinikubeButton *serviceButton;
+    MinikubeButton *mountButton;
+    MinikubeButton *tunnelButton;
+    MinikubeButton *sshButton;
+    MinikubeButton *dashboardButton;
+    MinikubeButton *addonsButton;
+    MinikubeButton *advancedButton;
+    MinikubeButton *settingsButton;
+    MinikubeButton *aboutButton;
+    MinikubeButton *exitButton;
     QIcon m_icon;
     MountList m_mountList;
     Setting m_setting;

--- a/src/minikubebutton.cpp
+++ b/src/minikubebutton.cpp
@@ -1,0 +1,43 @@
+#include "minikubebutton.h"
+
+MinikubeButton::MinikubeButton(QWidget *parent) : QPushButton(parent)
+{
+    // By default a button is enabled when instantiated
+    setStyleSheet(enabledStyleSheet);
+}
+
+MinikubeButton::MinikubeButton(const QString &text, QWidget *parent) : QPushButton(text, parent)
+{
+    setStyleSheet(enabledStyleSheet);
+}
+
+MinikubeButton::MinikubeButton(const QIcon &icon, const QString &text, QWidget *parent)
+    : QPushButton(icon, text, parent)
+{
+    setStyleSheet(enabledStyleSheet);
+}
+
+void MinikubeButton::setEnabled(bool enabled)
+{
+    QPushButton::setEnabled(enabled);
+    setStyleSheet(enabled ? enabledStyleSheet : diabledStyleSheet);
+}
+
+bool MinikubeButton::event(QEvent *event)
+{
+    switch (event->type()) {
+    case QEvent::HoverEnter:
+        if (isEnabled()) {
+            setStyleSheet(enabledHoverStyleSheet);
+        }
+        break;
+    case QEvent::HoverLeave:
+        if (isEnabled()) {
+            setStyleSheet(enabledStyleSheet);
+        }
+
+    default:
+        break;
+    }
+    return QPushButton::event(event);
+}

--- a/src/minikubebutton.h
+++ b/src/minikubebutton.h
@@ -1,0 +1,24 @@
+#ifndef MINIKUBEBUTTON_H
+#define MINIKUBEBUTTON_H
+#include <QPushButton>
+#include <QEvent>
+class MinikubeButton : public QPushButton
+{
+public:
+    explicit MinikubeButton(QWidget *parent = nullptr);
+    explicit MinikubeButton(const QString &text, QWidget *parent = nullptr);
+    MinikubeButton(const QIcon &icon, const QString &text, QWidget *parent = nullptr);
+
+    void setEnabled(bool enabled);
+
+    virtual bool event(QEvent *event) override;
+
+private:
+    const QString enabledStyleSheet = "";
+    const QString enabledHoverStyleSheet = "background-color:rgb(105,192,255,50)";
+
+    const QString diabledStyleSheet =
+            "background-color:rgb(191,191,191,50);color:rgb(140,140,140);";
+};
+
+#endif // MINIKUBEBUTTON_H


### PR DESCRIPTION
FIX #14  
Make button light blue when they are clickable, and make button gray when they are not clickable.
**Overview:**
This PR 

1. implemented a new button class extending QPushButton, overwriting setEnabled method. Newly overwritten setEnabled method sets buttons' background color according to whether it is enabled.
2. change buttons in BasicView and AdvancedView into this kind of new button.

**Before:**
![old](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/e8619864-a47a-41f8-a312-74c2194ffc0e)

**After:**
When the cursor is not hovering on any button, it looks like this: (white button means it is available, while gray button means it is not clickable)
![new_normal](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/a25b3759-3970-4fa8-9946-f5e63e324cfa)



When the cursor is hovering on a clickable button, it looks like this


![new_onhover](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/ffbd4f13-3be8-44af-98d9-e13979dbccc9)

