### PR TITLE
fix: fix progress window for 'minikube start'

### DIFF
--- a/src/operator.cpp
+++ b/src/operator.cpp
@@ -151,7 +151,6 @@ void Operator::createCluster(QStringList args)
 
 void Operator::startCommandStarting()
 {
-    commandStarting();
     m_progressWindow->setText("Starting...");
     m_progressWindow->show();
 }

--- a/src/progresswindow.cpp
+++ b/src/progresswindow.cpp
@@ -47,7 +47,7 @@ void ProgressWindow::show()
 {
     m_dialog->setWindowIcon(m_icon);
     m_dialog->resize(300, 150);
-    m_dialog->setWindowFlags(Qt::FramelessWindowHint);
+    m_dialog->setWindowFlags(m_dialog->windowFlags() | Qt::FramelessWindowHint);
     m_dialog->setModal(true);
 
     QVBoxLayout form(m_dialog);


### PR DESCRIPTION
FIX #73 
feat: set status to starting when starting minikube

When minikube is being started (by minikube-gui), both the system tray and the main window will show status "Starting"

Like this:
![06201](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/fdcc7d86-67f5-4a21-a2ae-06255e4646f4)

![06202](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/4ac379c0-e571-428f-a8e6-2d9cedf0d5cd)
