### PR TITLE
Fix macos download links

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,7 +1,7 @@
 [
     {
         "links": {
-            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.2.0/minikube-gui-mac.tar.gz",
+            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.2.0/minikube-gui-macos.tar.gz",
             "linux": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.2.0/minikube-gui-linux.tar.gz",
             "windows": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.2.0/minikube-gui-windows.zip"
         },
@@ -9,7 +9,7 @@
     },
     {
         "links": {
-            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.1.0/minikube-gui-mac.tar.gz",
+            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.1.0/minikube-gui-macos.tar.gz",
             "linux": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.1.0/minikube-gui-linux.tar.gz",
             "windows": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.1.0/minikube-gui-windows.zip"
         },
@@ -17,7 +17,7 @@
     },
     {
         "links": {
-            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.0.2/minikube-gui-mac.dmg",
+            "darwin": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.0.2/minikube-gui-macos.dmg",
             "linux": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.0.2/minikube-gui-linux.tar.gz",
             "windows": "https://github.com/kubernetes-sigs/minikube-gui/releases/download/v0.0.2/minikube-gui-windows.zip"
         },

--- a/scripts/update-releases-json.go
+++ b/scripts/update-releases-json.go
@@ -73,7 +73,7 @@ func updateReleases(version string) error {
 	linkBase := fmt.Sprintf("https://github.com/kubernetes-sigs/minikube-gui/releases/download/v%s/minikube-gui", version)
 	newRelease := release{
 		Links: links{
-			Darwin:  fmt.Sprintf("%s-mac.tar.gz", linkBase),
+			Darwin:  fmt.Sprintf("%s-macos.tar.gz", linkBase),
 			Linux:   fmt.Sprintf("%s-linux.tar.gz", linkBase),
 			Windows: fmt.Sprintf("%s-windows.zip", linkBase),
 		},


### PR DESCRIPTION
Uploaded artifacts suffix with `macos` not `mac`