### PR TITLE
feat: implement service table

### DIFF
--- a/src/commandrunner.cpp
+++ b/src/commandrunner.cpp
@@ -317,7 +317,7 @@ void CommandRunner::requestClusters()
 void CommandRunner::requestServiceList(QString pName)
 {
     m_command = "service";
-    QStringList args = { "-p", pName, "service", "list" };
+    QStringList args = { "-p", pName, "service", "list", "-o", "json" };
     executeMinikubeCommand(args);
 }
 

--- a/src/serviceview.cpp
+++ b/src/serviceview.cpp
@@ -19,29 +19,132 @@ limitations under the License.
 #include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QLabel>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QTableWidget>
+#include <QDebug>
+#include <QHeaderView>
+#include <QStandardPaths>
+#ifndef QT_NO_TERMWIDGET
+#include "qtermwidget.h"
+#include <QApplication>
+#endif
 
-ServiceView::ServiceView(QDialog *parent, QIcon icon)
+ServiceView::ServiceView(QDialog *parent, QIcon icon, CommandRunner *runner, Settings *settings)
 {
     m_parent = parent;
     m_icon = icon;
+    m_commandRunner = runner;
+    m_settings = settings;
 }
 
 void ServiceView::displayTable(QString svcCmdOutput)
 {
     m_dialog = new QDialog(m_parent);
+    m_dialog->setWindowFlags(m_dialog->windowFlags());
     m_dialog->setWindowTitle(tr("Service List"));
     m_dialog->setWindowIcon(m_icon);
-    m_dialog->setFixedWidth(600);
+    m_dialog->setMinimumWidth(800);
     m_dialog->setModal(true);
-    QFormLayout form(m_dialog);
-    QLabel *tableLbl = new QLabel();
-    tableLbl->setOpenExternalLinks(true);
-    tableLbl->setWordWrap(true);
-    tableLbl->setText(svcCmdOutput);
-    form.addRow(tableLbl);
-    QDialogButtonBox buttonBox(Qt::Horizontal, m_dialog);
+    QBoxLayout layout(QBoxLayout::TopToBottom, m_dialog);
+    QJsonParseError error;
+    QJsonDocument json = QJsonDocument::fromJson(svcCmdOutput.toUtf8(), &error);
+    if (json.isNull() || !json.isArray()) {
+        // cannot deseralize the output, print it to the dialog
+        qDebug() << error.errorString();
+        QLabel *tableLbl = new QLabel();
+        tableLbl->setOpenExternalLinks(true);
+        tableLbl->setWordWrap(true);
+        tableLbl->setText(svcCmdOutput);
+        layout.addWidget(tableLbl);
+    } else {
+        // can deseralize the output, generate a table
+        QJsonArray serviceArray = json.array();
+        QTableWidget *table = new QTableWidget(serviceArray.size(), 5);
+        table->resizeColumnsToContents();
+        QStringList headers({ "Namespace", "Name", "Target Port", "URL", "Actions" });
+        table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+        table->horizontalHeader()->setStretchLastSection(true);
+        table->setHorizontalHeaderLabels(headers);
+        for (int i = 0; i < serviceArray.size(); i++) {
+            QJsonObject obj = serviceArray[i].toObject();
+            QString nameSpace, serviceName;
+            if (obj.contains("Namespace")) {
+                nameSpace = obj["Namespace"].toString();
+                QTableWidgetItem *namespaceItem = new QTableWidgetItem(nameSpace);
+                table->setItem(i, 0, namespaceItem);
+            }
+            if (obj.contains("Name")) {
+                serviceName = obj["Name"].toString();
+                QTableWidgetItem *nameItem = new QTableWidgetItem(serviceName);
+                table->setItem(i, 1, nameItem);
+            }
+            if (obj.contains("PortNames")) {
+                QString listString =
+                        QJsonDocument(obj["PortNames"].toArray()).toJson(QJsonDocument::Compact);
+                QTableWidgetItem *portNamesItem = new QTableWidgetItem(listString);
+                table->setItem(i, 2, portNamesItem);
+            }
+            if (obj.contains("URLs")) {
+                QString listString =
+                        QJsonDocument(obj["URLs"].toArray()).toJson(QJsonDocument::Compact);
+                QTableWidgetItem *URLItem = new QTableWidgetItem(listString);
+                table->setItem(i, 3, URLItem);
+            }
+            QPushButton *button = new QPushButton();
+            button->setText("Connect");
+            table->setCellWidget(i, 4, button);
+            connect(button, &QPushButton::clicked, this, [this, serviceName, nameSpace]() -> void {
+                qDebug() << "here";
+                this->runMinikubeService(nameSpace, serviceName);
+            });
+        }
+        layout.addWidget(table);
+    }
+
+    QDialogButtonBox buttonBox(Qt::Horizontal);
     buttonBox.addButton(QString(tr("OK")), QDialogButtonBox::AcceptRole);
     connect(&buttonBox, &QDialogButtonBox::accepted, m_dialog, &QDialog::accept);
-    form.addRow(&buttonBox);
+    layout.addWidget(&buttonBox);
     m_dialog->exec();
+}
+
+void ServiceView::runMinikubeService(QString nameSpace, QString serviceName)
+{
+    QStringList commandArgs = { "service", "-n", nameSpace, serviceName };
+    QString command = m_settings->minikubePath() + " " + commandArgs.join(" ");
+
+#ifndef QT_NO_TERMWIDGET
+    int startnow = 0; // set shell program first
+
+    QTermWidget *console = new QTermWidget(startnow);
+
+    QFont font = QApplication::font();
+    font.setFamily("Monospace");
+    font.setPointSize(10);
+
+    console->setTerminalFont(font);
+    console->setColorScheme("Tango");
+    console->setShellProgram("eval");
+    console->setArgs({ commandArgs });
+    console->startShellProgram();
+
+#elif __APPLE__
+    QStringList arguments = { "-e", "tell app \"Terminal\"",
+                              "-e", "do script \"" + command + "\"",
+                              "-e", "activate",
+                              "-e", "end tell" };
+    m_commandRunner->executeCommand("/usr/bin/osascript", arguments);
+#else
+    QString terminal = qEnvironmentVariable("TERMINAL");
+    if (terminal.isEmpty()) {
+        terminal = "x-terminal-emulator";
+        if (QStandardPaths::findExecutable(terminal).isEmpty()) {
+            terminal = "xterm";
+        }
+    }
+
+    m_commandRunner->executeCommand(QStandardPaths::findExecutable(terminal), { "-e", command });
+#endif
 }

--- a/src/serviceview.h
+++ b/src/serviceview.h
@@ -19,20 +19,28 @@ limitations under the License.
 
 #include <QIcon>
 #include <QDialog>
+#include <QPushButton>
+#include <QProcess>
 
+#include "commandrunner.h"
 class ServiceView : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit ServiceView(QDialog *parent, QIcon icon);
+    explicit ServiceView(QDialog *parent, QIcon icon, CommandRunner *commandRunner,
+                         Settings *settings);
 
     void displayTable(QString);
 
 private:
+    void runMinikubeService(QString nameSpace, QString serviceName);
+
     QDialog *m_dialog;
     QIcon m_icon;
     QDialog *m_parent;
+    CommandRunner *m_commandRunner;
+    Settings *m_settings;
 };
 
 #endif // SERVICEVIEW_H

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -45,7 +45,7 @@ Window::Window()
     settings = new Settings();
     commandRunner = new CommandRunner(this, logger, settings);
     basicView = new BasicView(*trayIconIcon, version);
-    serviceView = new ServiceView(this, *trayIconIcon);
+    serviceView = new ServiceView(this, *trayIconIcon, commandRunner, settings);
     addonsView = new AddonsView(*trayIconIcon);
     advancedView = new AdvancedView(*trayIconIcon);
     errorMessage = new ErrorMessage(this, *trayIconIcon);


### PR DESCRIPTION
fix #75 
Now it pops up a windows with a table containing all information got from "minikube service list -o json"
like this

![0723](https://github.com/kubernetes-sigs/minikube-gui/assets/46831212/d0dfe2d6-83f6-4a9a-80eb-92bce048ab65)

When the connect buttons is cliked, it will try to run `minikube service -n <namespace> <serviceName>` in a new terminal