### PR TITLE
Fix subsequent starts not showing progress

### DIFF
--- a/src/progresswindow.cpp
+++ b/src/progresswindow.cpp
@@ -24,6 +24,7 @@ ProgressWindow::ProgressWindow(QWidget *parent, QIcon icon)
     m_icon = icon;
     m_parent = parent;
     m_dialog = new QDialog(m_parent);
+    m_dialog->setWindowFlags(Qt::FramelessWindowHint);
     m_text = new QLabel();
     m_progressBar = new QProgressBar();
 }
@@ -47,7 +48,6 @@ void ProgressWindow::show()
 {
     m_dialog->setWindowIcon(m_icon);
     m_dialog->resize(300, 150);
-    m_dialog->setWindowFlags(Qt::FramelessWindowHint);
     m_dialog->setModal(true);
 
     QVBoxLayout form(m_dialog);


### PR DESCRIPTION
### **Before:**
On the first start after opening the minikube-gui the progress bar was shown as expected, but subsequent starts the progress bar was not shown.

### **After:**
On subsequent starts the progress bar is also shown.

### **Cause:**
Looking at the docs for `setWindowFlags` I found the following:

> Note: This function calls [setParent](https://doc.qt.io/qt-5/qwidget.html#setParent)() when changing the flags for a window, causing the widget to be hidden. You must call [show](https://doc.qt.io/qt-5/qwidget.html#show)() to make the widget visible again.

https://doc.qt.io/qt-5/qwidget.html#windowFlags-prop

### **Solution:**
Moved `setWindowFlags` to the constructor since it only needs to be called once anyway, and fixes the issue.

### **Oddity:**
The one odd thing is that subsequent starts the blue of the `Cancel` button is lighter, not sure the cause of that but it's not an issue.

**First Start**
<img width="306" alt="Screenshot 2023-07-05 at 1 44 04 PM" src="https://github.com/kubernetes-sigs/minikube-gui/assets/44844360/91b8cfdc-0de8-4bf9-976a-8e5153222893">


**Subsequent Start**
<img width="307" alt="Screenshot 2023-07-05 at 1 44 27 PM" src="https://github.com/kubernetes-sigs/minikube-gui/assets/44844360/70537ce1-9b12-4d46-af7f-0628eb10b05d">
