### PR TITLE
feat: add Tiny button next to each feature for Documentation link

### DIFF
--- a/minikube.pro
+++ b/minikube.pro
@@ -14,6 +14,7 @@ HEADERS       = src/window.h \
                 src/operator.h \
                 src/paths.h \
                 src/progresswindow.h \
+                src/linkbutton.h \
                 src/serviceview.h \
                 src/setting.h \
                 src/settings.h \
@@ -34,6 +35,7 @@ SOURCES       = src/main.cpp \
                 src/operator.cpp \
                 src/paths.cpp \
                 src/progresswindow.cpp \
+                src/linkbutton.cpp \
                 src/serviceview.cpp \
                 src/setting.cpp \
                 src/settings.cpp \

--- a/src/basicview.cpp
+++ b/src/basicview.cpp
@@ -77,13 +77,13 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
     Fonts::setFontAwesome(aboutButton);
     Fonts::setFontAwesome(exitButton);
 
-    Fonts::setFontAwesome(dockerEnvLinkButton);
-    Fonts::setFontAwesome(serviceLinkButton);
-    Fonts::setFontAwesome(mountLinkButton);
-    Fonts::setFontAwesome(tunnelLinkButton);
-    Fonts::setFontAwesome(sshLinkButton);
-    Fonts::setFontAwesome(dashboardLinkButton);
-    Fonts::setFontAwesome(addonsLinkButton);
+    Fonts::setFontAwesomeTiny(dockerEnvLinkButton);
+    Fonts::setFontAwesomeTiny(serviceLinkButton);
+    Fonts::setFontAwesomeTiny(mountLinkButton);
+    Fonts::setFontAwesomeTiny(tunnelLinkButton);
+    Fonts::setFontAwesomeTiny(sshLinkButton);
+    Fonts::setFontAwesomeTiny(dashboardLinkButton);
+    Fonts::setFontAwesomeTiny(addonsLinkButton);
 
     topStatusButton->setToolTip(tr("cluster status, click to refresh"));
     dockerEnvButton->setToolTip(
@@ -106,23 +106,23 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
 
     QVBoxLayout *buttonLayoutRow2 = new QVBoxLayout;
 
-#define addRow(btn, linkbtn) do{        \
-    QHBoxLayout *row = new QHBoxLayout; \
-    row->addWidget(btn);                \
-    row->addWidget(linkbtn);            \
-    buttonLayoutRow2->addLayout(row);   \
+#define addCommandRow(btn, linkbtn) do{          \
+    QHBoxLayout *row = new QHBoxLayout;          \
+    row->addWidget(btn);                         \
+    row->addWidget(linkbtn, 0, Qt::AlignBottom); \
+    buttonLayoutRow2->addLayout(row);            \
 }while(0)
 
-    addRow(dockerEnvButton, dockerEnvLinkButton);
-    addRow(serviceButton, serviceLinkButton);
-    addRow(mountButton, mountLinkButton);
-    addRow(tunnelButton, tunnelLinkButton);
-    addRow(sshButton, sshLinkButton);
-    addRow(dashboardButton, dashboardLinkButton);
-    addRow(addonsButton, addonsLinkButton);
+    addCommandRow(dockerEnvButton, dockerEnvLinkButton);
+    addCommandRow(serviceButton, serviceLinkButton);
+    addCommandRow(mountButton, mountLinkButton);
+    addCommandRow(tunnelButton, tunnelLinkButton);
+    addCommandRow(sshButton, sshLinkButton);
+    addCommandRow(dashboardButton, dashboardLinkButton);
+    addCommandRow(addonsButton, addonsLinkButton);
     buttonLayoutRow2->addWidget(advancedButton);
 
-#undef addRow
+#undef addCommandRow
 
     QHBoxLayout *bottomBar = new QHBoxLayout;
     bottomBar->addWidget(settingsButton);

--- a/src/basicview.cpp
+++ b/src/basicview.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "basicview.h"
 #include "fonts.h"
 #include "constants.h"
+#include "linkbutton.h"
 
 #include <QDialog>
 #include <QFormLayout>
@@ -53,6 +54,14 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
     addonsButton = new QPushButton(tr("addons"));
     advancedButton = new QPushButton(tr("cluster list"));
 
+    dockerEnvLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/docker-env/");
+    serviceLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/service/");
+    mountLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/mount/");
+    tunnelLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/tunnel/");
+    sshLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/ssh/");
+    dashboardLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/dashboard/");
+    addonsLinkButton = new LinkButton(Constants::linkIcon, "https://minikube.sigs.k8s.io/docs/commands/addons/");
+
     refreshButton = new QPushButton(Constants::refreshIcon);
     settingsButton = new QPushButton(Constants::settingsIcon);
     aboutButton = new QPushButton(Constants::aboutIcon);
@@ -67,6 +76,14 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
     Fonts::setFontAwesome(settingsButton);
     Fonts::setFontAwesome(aboutButton);
     Fonts::setFontAwesome(exitButton);
+
+    Fonts::setFontAwesome(dockerEnvLinkButton);
+    Fonts::setFontAwesome(serviceLinkButton);
+    Fonts::setFontAwesome(mountLinkButton);
+    Fonts::setFontAwesome(tunnelLinkButton);
+    Fonts::setFontAwesome(sshLinkButton);
+    Fonts::setFontAwesome(dashboardLinkButton);
+    Fonts::setFontAwesome(addonsLinkButton);
 
     topStatusButton->setToolTip(tr("cluster status, click to refresh"));
     dockerEnvButton->setToolTip(
@@ -88,14 +105,24 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
     buttonLayoutRow1->addWidget(deleteButton);
 
     QVBoxLayout *buttonLayoutRow2 = new QVBoxLayout;
-    buttonLayoutRow2->addWidget(dockerEnvButton);
-    buttonLayoutRow2->addWidget(serviceButton);
-    buttonLayoutRow2->addWidget(mountButton);
-    buttonLayoutRow2->addWidget(tunnelButton);
-    buttonLayoutRow2->addWidget(sshButton);
-    buttonLayoutRow2->addWidget(dashboardButton);
-    buttonLayoutRow2->addWidget(addonsButton);
+
+#define addRow(btn, linkbtn) do{        \
+    QHBoxLayout *row = new QHBoxLayout; \
+    row->addWidget(btn);                \
+    row->addWidget(linkbtn);            \
+    buttonLayoutRow2->addLayout(row);   \
+}while(0)
+
+    addRow(dockerEnvButton, dockerEnvLinkButton);
+    addRow(serviceButton, serviceLinkButton);
+    addRow(mountButton, mountLinkButton);
+    addRow(tunnelButton, tunnelLinkButton);
+    addRow(sshButton, sshLinkButton);
+    addRow(dashboardButton, dashboardLinkButton);
+    addRow(addonsButton, addonsLinkButton);
     buttonLayoutRow2->addWidget(advancedButton);
+
+#undef addRow
 
     QHBoxLayout *bottomBar = new QHBoxLayout;
     bottomBar->addWidget(settingsButton);
@@ -129,6 +156,14 @@ BasicView::BasicView(QIcon icon,QVersionNumber version)
     connect(settingsButton, &QAbstractButton::clicked, this, &BasicView::askSettings);
     connect(aboutButton, &QAbstractButton::clicked, this, &BasicView::displayAbout);
     connect(exitButton, &QAbstractButton::clicked, qApp, &QCoreApplication::quit);
+
+    connect(dockerEnvLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(serviceLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(mountLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(tunnelLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(sshLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(dashboardLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
+    connect(addonsLinkButton, &LinkButton::openLink, this, &BasicView::openLink);
 }
 
 static QString getPauseLabel(bool isPaused)

--- a/src/basicview.h
+++ b/src/basicview.h
@@ -20,6 +20,7 @@ limitations under the License.
 #include "cluster.h"
 #include "mount.h"
 #include "setting.h"
+#include "linkbutton.h"
 
 #include <QPushButton>
 #include <QLabel>
@@ -56,6 +57,7 @@ signals:
     void closeMount();
     void tunnel();
     void addons();
+    void openLink(QString);
 
 private:
     QPushButton *topStatusButton;
@@ -64,6 +66,7 @@ private:
     QPushButton *pauseButton;
     QPushButton *deleteButton;
     QPushButton *refreshButton;
+
     QPushButton *dockerEnvButton;
     QPushButton *serviceButton;
     QPushButton *mountButton;
@@ -71,6 +74,15 @@ private:
     QPushButton *sshButton;
     QPushButton *dashboardButton;
     QPushButton *addonsButton;
+
+    LinkButton *dockerEnvLinkButton;
+    LinkButton *serviceLinkButton;
+    LinkButton *mountLinkButton;
+    LinkButton *tunnelLinkButton;
+    LinkButton *sshLinkButton;
+    LinkButton *dashboardLinkButton;
+    LinkButton *addonsLinkButton;
+
     QPushButton *advancedButton;
     QPushButton *settingsButton;
     QPushButton *aboutButton;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -23,7 +23,7 @@ const QString Constants::unPauseIcon = "\uf04b";
 const QString Constants::deleteIcon = "\uf1f8";
 const QString Constants::reloadIcon = "\uf021";
 const QString Constants::createIcon = "\uf0fe";
-const QString Constants::linkIcon = "\uf08e";
+const QString Constants::linkIcon = "\uf05a";
 
 const QString Constants::refreshIcon = "\uf021";
 const QString Constants::settingsIcon = "\uf1de";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -23,6 +23,7 @@ const QString Constants::unPauseIcon = "\uf04b";
 const QString Constants::deleteIcon = "\uf1f8";
 const QString Constants::reloadIcon = "\uf021";
 const QString Constants::createIcon = "\uf0fe";
+const QString Constants::linkIcon = "\uf08e";
 
 const QString Constants::refreshIcon = "\uf021";
 const QString Constants::settingsIcon = "\uf1de";

--- a/src/constants.h
+++ b/src/constants.h
@@ -33,6 +33,7 @@ public:
     static const QString reloadIcon;
     static const QString createIcon;
     static const QString refreshIcon;
+    static const QString linkIcon;
     static const QString settingsIcon;
     static const QString aboutIcon;
     static const QString exitIcon;

--- a/src/fonts.cpp
+++ b/src/fonts.cpp
@@ -37,7 +37,7 @@ void Fonts::loadFontAwesome()
     fontAwesome.setFamily("FontAwesome");
     fontAwesome.setPixelSize(20);
     fontAwesomeTiny.setFamily("FontAwesome");
-    fontAwesomeTiny.setPixelSize(10);
+    fontAwesomeTiny.setPixelSize(14);
 }
 
 void Fonts::setToolTipStyle()

--- a/src/fonts.cpp
+++ b/src/fonts.cpp
@@ -22,6 +22,7 @@ limitations under the License.
 #include <QPalette>
 
 QFont Fonts::fontAwesome;
+QFont Fonts::fontAwesomeTiny;
 
 void Fonts::initFonts()
 {
@@ -35,6 +36,8 @@ void Fonts::loadFontAwesome()
         qWarning() << "FontAwesome cannot be loaded!";
     fontAwesome.setFamily("FontAwesome");
     fontAwesome.setPixelSize(20);
+    fontAwesomeTiny.setFamily("FontAwesome");
+    fontAwesomeTiny.setPixelSize(10);
 }
 
 void Fonts::setToolTipStyle()
@@ -51,4 +54,9 @@ void Fonts::setToolTipStyle()
 void Fonts::setFontAwesome(QWidget *wid)
 {
     wid->setFont(fontAwesome);
+}
+
+void Fonts::setFontAwesomeTiny(QWidget *wid)
+{
+    wid->setFont(fontAwesomeTiny);
 }

--- a/src/fonts.h
+++ b/src/fonts.h
@@ -24,11 +24,13 @@ class Fonts
 public:
     static void initFonts();
     static void setFontAwesome(QWidget *wid);
+    static void setFontAwesomeTiny(QWidget *wid);
 
 private:
     static void loadFontAwesome();
     static void setToolTipStyle();
     static QFont fontAwesome;
+    static QFont fontAwesomeTiny;
 };
 
 #endif // FONTS_H

--- a/src/linkbutton.cpp
+++ b/src/linkbutton.cpp
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "linkbutton.h"
+#include "constants.h"
+#include "fonts.h"
+
+#include <QSize>
+
+LinkButton::LinkButton(const QString &icon, const QString &link, QWidget *parent)
+    : QPushButton(icon, parent), m_link(link)
+{
+    setFixedSize(QSize(28, 28));
+    connect(this, SIGNAL(clicked()), this, SLOT(emitOpenLink()));
+}
+
+void LinkButton::emitOpenLink()
+{
+    emit openLink(m_link);
+}

--- a/src/linkbutton.cpp
+++ b/src/linkbutton.cpp
@@ -23,8 +23,14 @@ limitations under the License.
 LinkButton::LinkButton(const QString &icon, const QString &link, QWidget *parent)
     : QPushButton(icon, parent), m_link(link)
 {
-    setFixedSize(QSize(28, 28));
+    setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     connect(this, SIGNAL(clicked()), this, SLOT(emitOpenLink()));
+}
+
+QSize LinkButton::sizeHint() const
+{
+    int x=font().pixelSize()+8;
+    return QSize(x, x);
 }
 
 void LinkButton::emitOpenLink()

--- a/src/linkbutton.cpp
+++ b/src/linkbutton.cpp
@@ -35,7 +35,11 @@ QSize LinkButton::sizeHint() const
     return QSize(x, x);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void LinkButton::enterEvent(QEnterEvent *event)
+#else
+void LinkButton::enterEvent(QEvent *event)
+#endif
 {
     setStyleSheet("QPushButton { color: dark; background-color: transparent; border: none; }");
 }

--- a/src/linkbutton.cpp
+++ b/src/linkbutton.cpp
@@ -18,12 +18,14 @@ limitations under the License.
 #include "constants.h"
 #include "fonts.h"
 
-#include <QSize>
+#include <QPalette>
 
 LinkButton::LinkButton(const QString &icon, const QString &link, QWidget *parent)
     : QPushButton(icon, parent), m_link(link)
 {
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    setStyleSheet("QPushButton { color: gray; background-color: transparent; border: none; }");
+    setToolTip("Open documentation on the default browser.");
     connect(this, SIGNAL(clicked()), this, SLOT(emitOpenLink()));
 }
 
@@ -31,6 +33,16 @@ QSize LinkButton::sizeHint() const
 {
     int x=font().pixelSize()+8;
     return QSize(x, x);
+}
+
+void LinkButton::enterEvent(QEnterEvent *event)
+{
+    setStyleSheet("QPushButton { color: dark; background-color: transparent; border: none; }");
+}
+
+void LinkButton::leaveEvent(QEvent *event)
+{
+    setStyleSheet("QPushButton { color: gray; background-color: transparent; border: none; }");
 }
 
 void LinkButton::emitOpenLink()

--- a/src/linkbutton.h
+++ b/src/linkbutton.h
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef LINKBUTTON_H
+#define LINKBUTTON_H
+
+#include <QPushButton>
+
+class LinkButton: public QPushButton
+{
+    Q_OBJECT
+
+public:
+    explicit LinkButton(const QString &icon, const QString &link, QWidget *parent = nullptr);
+       
+signals:
+    void openLink(const QString &link);
+
+private slots:
+    void emitOpenLink();
+
+private:
+    QString m_link;
+};
+
+#endif // PUSHBUTTONWITHLINK_H

--- a/src/linkbutton.h
+++ b/src/linkbutton.h
@@ -18,6 +18,8 @@ limitations under the License.
 #define LINKBUTTON_H
 
 #include <QPushButton>
+#include <QSize>
+#include <QEnterEvent>
 
 class LinkButton: public QPushButton
 {
@@ -29,6 +31,10 @@ public:
        
 signals:
     void openLink(const QString &link);
+
+protected:
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
 
 private slots:
     void emitOpenLink();

--- a/src/linkbutton.h
+++ b/src/linkbutton.h
@@ -33,7 +33,11 @@ signals:
     void openLink(const QString &link);
 
 protected:
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEnterEvent *event) override;
+#else
+    void enterEvent(QEvent *event) override;
+#endif
     void leaveEvent(QEvent *event) override;
 
 private slots:

--- a/src/linkbutton.h
+++ b/src/linkbutton.h
@@ -25,6 +25,7 @@ class LinkButton: public QPushButton
 
 public:
     explicit LinkButton(const QString &icon, const QString &link, QWidget *parent = nullptr);
+    QSize sizeHint() const override;
        
 signals:
     void openLink(const QString &link);

--- a/src/operator.cpp
+++ b/src/operator.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include <QPushButton>
 #include <QStandardPaths>
 #include <QDebug>
+#include <QDesktopServices>
 
 Operator::Operator(AdvancedView *advancedView, BasicView *basicView, ServiceView *serviceView,
                    AddonsView *addonsView, CommandRunner *commandRunner, ErrorMessage *errorMessage,
@@ -61,6 +62,7 @@ Operator::Operator(AdvancedView *advancedView, BasicView *basicView, ServiceView
     connect(m_basicView, &BasicView::ssh, this, &Operator::sshConsole);
     connect(m_basicView, &BasicView::dashboard, this, &Operator::dashboardBrowser);
     connect(m_basicView, &BasicView::advanced, this, &Operator::toAdvancedView);
+    connect(m_basicView, &BasicView::openLink, this, &Operator::openLink);
 
     connect(m_advancedView, &AdvancedView::start, this, &Operator::startMinikube);
     connect(m_advancedView, &AdvancedView::stop, this, &Operator::stopMinikube);
@@ -541,4 +543,9 @@ void Operator::dashboardClose()
         dashboardProcess->terminate();
         dashboardProcess->waitForFinished();
     }
+}
+
+void Operator::openLink(QString link)
+{
+    QDesktopServices::openUrl(QUrl(link));
 }

--- a/src/operator.h
+++ b/src/operator.h
@@ -91,6 +91,7 @@ private:
     void disableButtons();
     void updateAddons();
     void displayAddons();
+    void openLink(QString);
 
     AdvancedView *m_advancedView;
     BasicView *m_basicView;


### PR DESCRIPTION
Implemented issue #25. Will open URL like https://minikube.sigs.k8s.io/docs/commands/XXX using the default browser.

![Screenshot from 2023-07-19 16-24-33](https://github.com/kubernetes-sigs/minikube-gui/assets/30122160/ee104954-a697-4aa4-8777-189b4471e988)
