### PR TITLE
Make AppDir and AppImage the default for linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,12 @@ jobs:
           curl -LO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
       - name: install linuxdeployqt
         run: |
-          sudo install linuxdeployqt-continuous-x86_64.AppImage /usr/local/bin/linuxdeployqt
+          chmod +x linuxdeployqt-continuous-x86_64.AppImage
+          ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract
+          sudo cp -pr squashfs-root/usr/bin/* /usr/bin/
+          sudo cp -pr squashfs-root/usr/lib/* /usr/lib/
+          rm -rf squashfs-root
+          chmod -x linuxdeployqt-continuous-x86_64.AppImage
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,19 @@ jobs:
       - uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           cache: true
+      - name: cache linuxdeployqt
+        id: cache-appimage
+        uses: actions/cache@v3
+        with:
+          path: linuxdeployqt-continuous-x86_64.AppImage
+          key: linuxdeployqt-x86_64
+      - if: ${{ steps.cache-appimage.outputs.cache-hit != 'true' }}
+        name: download linuxdeployqt
+        run: |
+          curl -LO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+      - name: install linuxdeployqt
+        run: |
+          sudo install linuxdeployqt-continuous-x86_64.AppImage /usr/local/bin/linuxdeployqt
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: minikube-gui-linux
-          path: ./minikube-gui-linux.tar.gz
+          path: ./minikube-gui-linux.AppImage

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,6 +32,11 @@ jobs:
           sudo cp -pr squashfs-root/usr/lib/* /usr/lib/
           rm -rf squashfs-root
           chmod -x linuxdeployqt-continuous-x86_64.AppImage
+      - name: cache adwaita-qt
+        uses: actions/cache@v3
+        with:
+          path: adwaita-qt-1.4.2.tar.gz
+          key: adwaita-qt-1.4.2.tar.gz
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,8 @@ on:
       - main
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    # AppImage requires ubuntu focal
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -18,6 +18,19 @@ jobs:
       - uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           cache: true
+      - name: cache linuxdeployqt
+        id: cache-appimage
+        uses: actions/cache@v3
+        with:
+          path: linuxdeployqt-continuous-x86_64.AppImage
+          key: linuxdeployqt-x86_64
+      - if: ${{ steps.cache-appimage.outputs.cache-hit != 'true' }}
+        name: download linuxdeployqt
+        run: |
+          curl -LO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+      - name: install linuxdeployqt
+        run: |
+          sudo install linuxdeployqt-continuous-x86_64.AppImage /usr/local/bin/linuxdeployqt
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -30,7 +30,12 @@ jobs:
           curl -LO https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
       - name: install linuxdeployqt
         run: |
-          sudo install linuxdeployqt-continuous-x86_64.AppImage /usr/local/bin/linuxdeployqt
+          chmod +x linuxdeployqt-continuous-x86_64.AppImage
+          ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract
+          sudo cp -pr squashfs-root/usr/bin/* /usr/bin/
+          sudo cp -pr squashfs-root/usr/lib/* /usr/lib/
+          rm -rf squashfs-root
+          chmod -x linuxdeployqt-continuous-x86_64.AppImage
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -37,6 +37,11 @@ jobs:
           sudo cp -pr squashfs-root/usr/lib/* /usr/lib/
           rm -rf squashfs-root
           chmod -x linuxdeployqt-continuous-x86_64.AppImage
+      - name: cache adwaita-qt
+        uses: actions/cache@v3
+        with:
+          path: adwaita-qt-1.4.2.tar.gz
+          key: adwaita-qt-1.4.2.tar.gz
       - name: build
         run: |
           make build-linux

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: minikube-gui-linux-release
+          path: ./minikube-gui-linux.AppImage
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: minikube-gui-linux-tar-release
           path: ./minikube-gui-linux.tar.gz
   build-macos-release:
     runs-on: macos-latest

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -12,7 +12,8 @@ jobs:
           git tag "v$VERSION"
           git push origin "v$VERSION"
   build-linux-release:
-    runs-on: ubuntu-latest
+    # AppImage requires ubuntu focal
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,8 +17,9 @@ build-linux: ## Build minikube-gui for Linux
 	qmake
 	make -f Makefile
 	scripts/build-linux.sh
+	scripts/build-adwaita.sh
 	export VERSION=$(subst v,,$(VERSION)) && \
-	(cd ./bin && linuxdeployqt usr/share/applications/minikube-gui.desktop -verbose=1 -appimage)
+	(cd ./bin && linuxdeployqt usr/share/applications/minikube-gui.desktop -verbose=1 -appimage -executable=usr/plugins/styles/adwaita.so)
 	mv ./bin/*.AppImage ./minikube-gui-linux.AppImage
 	tar -czvf minikube-gui-linux.tar.gz -C ./bin .
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,11 @@
 build-linux: ## Build minikube-gui for Linux
 	qmake
 	make -f Makefile
-	tar -czvf minikube-gui-linux.tar.gz -C ./bin ./minikube-gui
+	scripts/build-linux.sh
+	export VERSION=$(subst v,,$(VERSION)) && \
+	(cd ./bin && linuxdeployqt usr/share/applications/minikube-gui.desktop -verbose=1 -appimage)
+	mv ./bin/*.AppImage ./minikube-gui-linux.AppImage
+	tar -czvf minikube-gui-linux.tar.gz -C ./bin .
 
 .PHONY: build-macos
 build-macos: ## Build minikube-gui for macOS

--- a/resources/minikube-gui.desktop
+++ b/resources/minikube-gui.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Minikube
+Exec=minikube-gui
+Icon=minikube
+Categories=Development;

--- a/scripts/build-adwaita.sh
+++ b/scripts/build-adwaita.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+ADWAITAQT_VERSION=1.4.2
+
+sudo -n apt-get update ||:
+sudo -n apt-get install -y cmake make pkg-config libx11-dev xcb libx11-xcb-dev libxkbcommon-dev sassc ||:
+
+test -r adwaita-qt-${ADWAITAQT_VERSION}.tar.gz || \
+curl -RLOJ https://github.com/FedoraQt/adwaita-qt/archive/refs/tags/${ADWAITAQT_VERSION}.tar.gz
+mkdir -p bin
+cd bin
+tar xzf ../adwaita-qt-${ADWAITAQT_VERSION}.tar.gz
+cd adwaita-qt-${ADWAITAQT_VERSION}
+patch -p1 <<EOF
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de9249e..9558d77 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ project(Adwaita)
+ 
+-cmake_minimum_required(VERSION 3.17)
++cmake_minimum_required(VERSION 3.16)
+ 
+ set(ADWAITAQT_VERSION_MAJOR 1)
+ set(ADWAITAQT_VERSION "1.4.2")
+@@ -13,7 +13,7 @@ if (USE_QT6)
+     set(CMAKE_CXX_STANDARD_REQUIRED ON)
+     set(ADWAITAQT_SUFFIX "6")
+ else()
+-    set(QT_MIN_VERSION "5.15.2")
++    set(QT_MIN_VERSION "5.12.8")
+     set(CMAKE_CXX_STANDARD 11)
+     set(CMAKE_CXX_STANDARD_REQUIRED ON)
+     set(ADWAITAQT_SUFFIX "")
+EOF
+mkdir -p build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DQT_PLUGINS_DIR=/usr/plugins -DCMAKE_BUILD_TYPE=RelWithDebInfo
+make -j2 VERBOSE=1
+cd ..
+mkdir dest
+make -C build -s install DESTDIR=$PWD/dest
+make -C build -s clean
+cd ..
+set -x
+mkdir -p usr/lib
+cp adwaita-qt-${ADWAITAQT_VERSION}/dest/usr/lib/*/libadwaitaqt.so.1 usr/lib
+cp adwaita-qt-${ADWAITAQT_VERSION}/dest/usr/lib/*/libadwaitaqtpriv.so.1 usr/lib
+mkdir -p usr/plugins/styles
+cp adwaita-qt-${ADWAITAQT_VERSION}/dest/usr/plugins/styles/adwaita.so usr/plugins/styles
+set +x
+rm -r adwaita-qt-${ADWAITAQT_VERSION}
+cd ..

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -x
+mkdir -p ./bin/usr/bin
+cp bin/minikube-gui ./bin/usr/bin
+mkdir -p ./bin/usr/share/applications
+cp resources/minikube-gui.desktop ./bin/usr/share/applications
+mkdir -p ./bin/usr/share/icons/hicolor/512x512/apps
+cp resources/images/minikube.png ./bin/usr/share/icons/hicolor/512x512/apps


### PR DESCRIPTION
Add [AppDir](https://en.wikipedia.org/wiki/Application_directory) files to the tarball so that is possible to run.

`AppRun  .DirIcon  minikube-gui  minikube-gui.desktop  minikube.png  usr/`

Create an [AppImage](https://appimage.org/) to get an all-in-one similar to the dmg.

`minikube-gui-linux.AppImage` 

Closes #49

----

Uses:

* https://github.com/probonopd/linuxdeployqt

See also:

* https://docs.appimage.org/packaging-guide/manual.html